### PR TITLE
Fix bug in result set view introduced by PR #224

### DIFF
--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -156,9 +156,9 @@ export function generateScroller(basicSelect: string, isCL: boolean): string {
             jobIdCell.id = jobId;
             jobIdCell.appendChild(document.createTextNode(' '));
 
-            if (columns.length > 2) {
+            if (columnMetaData.length > 2) {
               statusCell.colSpan = 2;
-              jobIdCell.colSpan = columns.length - 2;
+              jobIdCell.colSpan = columnMetaData.length - 2;
             }
           }
 


### PR DESCRIPTION
A non-existent variable is referenced in the javascript in the generated HTML for displaying results.

Change to use the correct variable.